### PR TITLE
Upgrade to 1.6.1

### DIFF
--- a/src/manifests/pipelines.yaml
+++ b/src/manifests/pipelines.yaml
@@ -70,6 +70,8 @@ rules:
   - retry
   - terminate
   - unarchive
+  - reportMetrics
+  - readArtifact
 - apiGroups:
   - pipelines.kubeflow.org
   resources:
@@ -112,11 +114,18 @@ rules:
   - pipelines
   - pipelines/versions
   - experiments
-  - runs
   - jobs
   verbs:
   - get
   - list
+- apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - runs
+  verbs:
+  - get
+  - list
+  - readArtifact
 - apiGroups:
   - kubeflow.org
   resources:


### PR DESCRIPTION
Update pipelines roles according to the changes in 2.0.0-alpha.5 Changes can be seen in this upstream PR [#2287](https://github.com/kubeflow/manifests/pull/2287).