### PR TITLE
feat: refactor integration tests to use lightkube

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,5 +51,8 @@ jobs:
             provider: microk8s
             channel: 1.22/stable
             charmcraft-channel: latest/candidate
+            # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
+            # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
+            bootstrap-options: --agent-version="2.9.34"
 
       - run: sg microk8s -c "KUBECONFIG=$HOME/.kube/config tox -e integration"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 black
 flake8<4.1
-juju<2.10
+juju==3.0.*
 pytest<6.3

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,4 +48,3 @@ async def test_clusterroles_created(ops_test):
     expected_rules = {e["metadata"]["name"]: e["rules"] for e in expected}
 
     assert list(created_rules.keys()) == list(expected_rules.keys())
-

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,8 @@ commands = pytest -vvs {toxinidir}/tests/unit {posargs}
 
 [testenv:integration]
 deps =
+    pytest
     pytest-operator
+    lightkube
+    lightkube-models<1.23
 commands = pytest -vvs --log-cli-level=INFO {toxinidir}/tests/integration {posargs}


### PR DESCRIPTION
Previous tests were failing as they did not have access to kubectl.  This refactors the tests to use lightkube.