### PR TITLE
fix: Pin GitHub runner to ubuntu 20.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - run: pip install tox
@@ -33,7 +33,7 @@ jobs:
 
   unit-test:
     name: Unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: pip install tox
@@ -41,7 +41,7 @@ jobs:
 
   integration-test:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel


### PR DESCRIPTION
Pins github runners to ubuntu-20.04 to avoid problems in publishing and tests

Merge after #21 