### PR TITLE
feat: update to 1.6.1 in track/1.6

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,5 +51,8 @@ jobs:
             provider: microk8s
             channel: 1.22/stable
             charmcraft-channel: latest/candidate
+            # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
+            # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
+            bootstrap-options: --agent-version="2.9.34"
 
       - run: sg microk8s -c "KUBECONFIG=$HOME/.kube/config tox -e integration"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - run: pip install tox
@@ -33,7 +33,7 @@ jobs:
 
   unit-test:
     name: Unit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: pip install tox
@@ -41,7 +41,7 @@ jobs:
 
   integration-test:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel

--- a/src/manifests/pipelines.yaml
+++ b/src/manifests/pipelines.yaml
@@ -70,6 +70,8 @@ rules:
   - retry
   - terminate
   - unarchive
+  - reportMetrics
+  - readArtifact
 - apiGroups:
   - pipelines.kubeflow.org
   resources:
@@ -112,11 +114,18 @@ rules:
   - pipelines
   - pipelines/versions
   - experiments
-  - runs
   - jobs
   verbs:
   - get
   - list
+- apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - runs
+  verbs:
+  - get
+  - list
+  - readArtifact
 - apiGroups:
   - kubeflow.org
   resources:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 black
 flake8<4.1
-juju<2.10
+juju==3.0.*
 pytest<6.3

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,4 +48,3 @@ async def test_clusterroles_created(ops_test):
     expected_rules = {e["metadata"]["name"]: e["rules"] for e in expected}
 
     assert list(created_rules.keys()) == list(expected_rules.keys())
-

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,8 @@ commands = pytest -vvs {toxinidir}/tests/unit {posargs}
 
 [testenv:integration]
 deps =
+    pytest
     pytest-operator
+    lightkube
+    lightkube-models<1.23
 commands = pytest -vvs --log-cli-level=INFO {toxinidir}/tests/integration {posargs}


### PR DESCRIPTION
This backports:
* updating kubeflow-roles to v1.6.1
* fixes to CI (linting, pinning juju-agent, pinning runner ubuntu versions, etc)