### PR TITLE
ci: k8s version bump 1.2x -> 1.24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            channel: 1.22/stable
+            channel: 1.24/stable
             charmcraft-channel: latest/candidate
             # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
             # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3


### PR DESCRIPTION
[skip ci] ci: k8s version bump 1.2x -> 1.24