### PR TITLE
Fix: create experiment permission denied 1.7

### DIFF
--- a/src/manifests/pipelines.yaml
+++ b/src/manifests/pipelines.yaml
@@ -37,6 +37,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+    application-crd-id: kubeflow-pipelines
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
   name: aggregate-to-kubeflow-pipelines-edit
 rules:

--- a/src/manifests/pipelines.yaml
+++ b/src/manifests/pipelines.yaml
@@ -8,9 +8,35 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: ml-pipeline
-    app.kubernetes.io/name: kubeflow-pipelines
-    application-crd-id: kubeflow-pipelines
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-pipelines-edit
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-pipelines-view
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-view: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipelines-edit: "true"
   name: aggregate-to-kubeflow-pipelines-edit
 rules:


### PR DESCRIPTION
fixes [pipelines issue](https://github.com/canonical/kfp-operators/issues/156)
add missing roles `kubeflow-pipelines-edit` and `kubeflow-pipelines-view`

## Manual testing:
- run `juju refresh --path=./kubeflow-roles_ubuntu-20.04-amd64.charm kubeflow-roles`
- go to Pipelines in the dashboard
- upload pipeline from file
- click create
- pipeline and experiment created 