### PR TITLE
fix: add back seldon aggregation rules

### DIFF
--- a/src/manifests/seldon.yaml
+++ b/src/manifests/seldon.yaml
@@ -1,0 +1,19 @@
+# manifests/contrib/seldon/seldon-core-operator/base/kubeflow-edit-seldon.yaml
+
+# Kubeflow builds clusterrole kubeflow-edit by aggreagating multiple other clusterroles
+# So i add a clusterrole that allows seldon deployments and it will be aggreagted because
+# of its "aggregate-to-kubeflow-edit" label
+# kubeflow-edit is the default role, that is available in each user namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-edit-seldon
+rules:
+- apiGroups:
+    - machinelearning.seldon.io
+  verbs:
+    - '*'
+  resources:
+    - '*'


### PR DESCRIPTION
This role was removed thinking that seldon-core-operator would handle the aggregated role by itself after the charm refactor from pod spec to sidecar. For more details please refer to the issue below.

Fixes canonical/seldon-core-operator#113