### PR TITLE
feat: add development section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ To install Kubeflow Roles, run:
     juju deploy kubeflow-roles
 
 For more information, see https://juju.is/docs
+
+## Development
+
+On migration of a Podspec charm to sidecar, you should move the application-specific `ClusterRoles` from this charm to the charm's Auth manifests. Sidecar charms can create a custom `ClusterRole`.


### PR DESCRIPTION
add development section to explicitly state that sidecar charms should deploy their own aggregation `ClusterRoles`