### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in main

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -43,6 +43,6 @@ jobs:
             provider: microk8s
             channel: 1.25-strict/stable
             charmcraft-channel: latest/candidate
-            juju-channel: 3.5/stable
+            juju-channel: 3.4/stable
 
       - run: sg snap_microk8s -c "KUBECONFIG=$HOME/.kube/config tox -e integration"


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944