### PR TITLE
feat: add kubeflow-tokens-edit ClusterRole (#114)

### DIFF
--- a/src/manifests/kubeflow-roles.yaml
+++ b/src/manifests/kubeflow-roles.yaml
@@ -321,3 +321,26 @@ rules:
   - get
   - list
   - watch
+---
+# Charmed Kubeflow specific ClusterRole that allows Kubeflow users
+# to manipulate ServiceAccount tokens
+# Do not remove on upgrade, see canonical/kubeflow-roles-operator#113
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-tokens-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,6 +34,7 @@ async def test_clusterroles_created(ops_test):
         "kubeflow-kubernetes-admin",
         "kubeflow-kubernetes-edit",
         "kubeflow-kubernetes-view",
+        "kubeflow-tokens-edit",
     ]
 
     for clusterrole_name in clusterrole_names:


### PR DESCRIPTION
Backports #114 to `track/1.10`
Closes https://github.com/canonical/bundle-kubeflow/issues/1281

## Summary
* feat: add kubeflow-tokens-edit ClusterRole

The rules in this ClusterRole will be aggregated to the RBAC of the default-editor ServiceAccount to allow Kubeflow users to manipulate ServiceAccount tokens.

Fixes #113